### PR TITLE
Improve error messages

### DIFF
--- a/src/references.rs
+++ b/src/references.rs
@@ -36,11 +36,20 @@ impl From<&[Arc<TicketQuery>]> for ReferenceQueries {
 
         // I don't know how to accomplish this in a functional style, unfortunately.
         for query in item {
-            for reference in &query.references {
-                reference_queries.push(Arc::clone(reference));
+            if !query.references.is_empty() {
+                log::info!(
+                    "Query {:?} has {} reference(s)",
+                    query.using,
+                    query.references.len()
+                );
+                for reference in &query.references {
+                    log::info!("  Reference: {:?}", reference.using);
+                    reference_queries.push(Arc::clone(reference));
+                }
             }
         }
 
+        log::info!("Total reference queries extracted: {}", reference_queries.len());
         Self(reference_queries)
     }
 }

--- a/src/status_report.rs
+++ b/src/status_report.rs
@@ -586,7 +586,7 @@ fn extract_number(caps: &regex::Captures, index: usize) -> Option<u32> {
 }
 
 /// List the most common release set in the tickets.
-fn most_common_release(tickets: &[AbstractTicket]) -> Option<Version> {
+fn most_common_release(tickets: &[AbstractTicket]) -> Option<Version<'_>> {
     let mut releases: Counter<Version> = Counter::new();
 
     // Releases are a list, and each ticket can have several of them.


### PR DESCRIPTION
* References for tickets that have them are now logged. This helps with troubleshooting.
* Improve error message when a ticket was moved from one project to another.
* Print direct link to the issue, when the ticket has missing fields. 